### PR TITLE
Avoid colors when outputting to a pipe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -592,6 +592,12 @@
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true
     },
+    "nan": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "dev": true
+    },
     "node-environment-flags": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
@@ -600,6 +606,15 @@
       "requires": {
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
+      }
+    },
+    "node-pty": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-0.9.0.tgz",
+      "integrity": "sha512-MBnCQl83FTYOu7B4xWw10AW77AAh7ThCE1VXEv+JeWj8mSpGo+0bwgsV+b23ljBFwEM9OmsOv3kM27iUPPm84g==",
+      "dev": true,
+      "requires": {
+        "nan": "^2.14.0"
       }
     },
     "normalize-path": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"@types/mocha": "^7.0.1",
 		"@types/node": "^13.7.2",
 		"mocha": "^7.0.1",
+		"node-pty": "^0.9.0",
 		"rimraf": "^3.0.2",
 		"ts-node": "^8.6.2",
 		"typescript": "^3.7.5"

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,13 @@
 import * as k from './index';
 import * as t from 'assert';
+import * as pty from 'node-pty';
+import * as path from 'path';
+import * as child_process from 'child_process';
+
 
 describe('colors', () => {
+	k.options.enabled = true; // Always enable colors, even in CLI environments
+
 	it('should print colors', () => {
 		t.equal(k.cyan('foo'), '\u001b[36mfoo\u001b[39m');
 	});
@@ -46,6 +52,40 @@ describe('colors', () => {
 		k.options.enabled = true;
 		t.equal(k.cyan('foo'), '\u001b[36mfoo\u001b[39m');
 	});
+});
+
+describe('color switch', () => {
+	it('should be enabled in terminals by default', done => {
+		let output = '';
+		const term = pty.spawn(path.join(__dirname, '..', 'node_modules/.bin/ts-node'), [
+			'-e', 'console.log(require("./index.ts").blue("foo"))'
+		], {
+			name: 'test with pseudo tty',
+			cols: 80,
+			rows: 30,
+			cwd: __dirname,
+		});
+		term.onData(data => output += data);
+		term.onExit(() => {
+			t.equal(JSON.stringify(output.trim()), JSON.stringify('\x1B[34mfoo\x1B[39m'));
+			done();
+		});
+	}).timeout(20000); // typescript is slow
+
+	it('should be disabled in non-interactive terminals', done => {
+		let output = '';
+		const subprocess = child_process.spawn(path.join(__dirname, '..', 'node_modules/.bin/ts-node'), [
+			'-e', 'console.log(require("./index.ts").blue("foo"))'
+		], {
+			cwd: __dirname,
+			stdio: 'pipe',
+		});
+		subprocess.stdout.on('data', data => output += data);
+		subprocess.on('exit', () => {
+			t.equal(JSON.stringify(output.trim()), JSON.stringify('foo'));
+			done();
+		});
+	}).timeout(20000); // typescript is slow
 });
 
 describe('strip colors', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 const { FORCE_COLOR, NODE_DISABLE_COLORS, TERM } = process.env;
 
 export let options = {
-	enabled: !NODE_DISABLE_COLORS && TERM !== 'dumb' && FORCE_COLOR !== '0',
+	enabled: (!NODE_DISABLE_COLORS && TERM !== 'dumb' && FORCE_COLOR !== '0' && process.stdout.isTTY),
 };
 
 function kolorist(start: number, end: number) {


### PR DESCRIPTION
kolorist only makes sense for TTYs with color displays. When redirecting the output to a pipe, colors should be suppressed by default.
