### PR TITLE
Fix: runtime error if TERM is not defined in env

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,11 +30,9 @@ if (globalVar.process && globalVar.process.env && globalVar.process.stdout) {
 		process.stdout.isTTY;
 
 	if (enabled) {
-		if (TERM.endsWith('-256color')) {
-			supportLevel = SupportLevel.ansi256;
-		} else {
-			supportLevel = SupportLevel.ansi;
-		}
+		supportLevel = TERM?.endsWith('-256color')
+			? SupportLevel.ansi256
+			: SupportLevel.ansi;
 	}
 }
 


### PR DESCRIPTION
Hi, the latest release (1.3.0) broke @vitejs/create-app on windows (https://github.com/vitejs/vite/issues/2568), so I'm suggesting a fix (by adding an optional-chaining to TERM.endswith). I also switched if/else to a ternary operator since it only had assignment to the same variable.