### PR TITLE
Fix: optional chaining isn't compiled away by TS as I thought

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ if (globalVar.process && globalVar.process.env && globalVar.process.stdout) {
 		process.stdout.isTTY;
 
 	if (enabled) {
-		supportLevel = TERM?.endsWith('-256color')
+		supportLevel = TERM && TERM.endsWith('-256color')
 			? SupportLevel.ansi256
 			: SupportLevel.ansi;
 	}


### PR DESCRIPTION
Sorry, but the last PR seems to only work for node >= 14 so this change addresses that for the time being.