### PR TITLE
Feature: Allow forcing color with FORCE_COLOR=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,15 @@ import { red, cyan } from 'kolorist';
 console.log(red(`Error: something failed in ${cyan('my-file.js')}.`));
 ```
 
-You can also disable colors globally via the following environment variables:
+You can also disable or enable colors globally via the following environment variables:
 
-- `NODE_DISABLE_COLORS`
-- `TERM=dumb`
-- `FORCE_COLOR=0`
+- disable:
+  - `NODE_DISABLE_COLORS`
+  - `TERM=dumb`
+  - `FORCE_COLOR=0`
+
+- enable:
+  - `FORCE_COLOR=1`
 
 On top of that you can disable colors right from node:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,11 +23,13 @@ let supportLevel: SupportLevel = SupportLevel.none;
 
 if (globalVar.process && globalVar.process.env && globalVar.process.stdout) {
 	const { FORCE_COLOR, NODE_DISABLE_COLORS, TERM } = globalVar.process.env;
-	enabled =
-		!NODE_DISABLE_COLORS &&
-		TERM !== 'dumb' &&
-		FORCE_COLOR !== '0' &&
-		process.stdout.isTTY;
+	if (NODE_DISABLE_COLORS || FORCE_COLOR === '0') {
+		enabled = false;
+	} else if (FORCE_COLOR === '1') {
+		enabled = true;
+	} else {
+		enabled = TERM !== 'dumb' && process.stdout.isTTY;
+	}
 
 	if (enabled) {
 		supportLevel = TERM && TERM.endsWith('-256color')


### PR DESCRIPTION
This PR adds a new way to force color globally with `FORCE_COLOR=1`.

I need this to enable colors when using `swc` spawned from another process and capturing its output, as there is no easy way to make `stdout.isTTY` to `true` in this case. Another solution would be to implement a CLI flag in `swc`.