### PR TITLE
Fix unable to bundle with esbuild es5

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 	},
 	"exports": {
 		".": {
+			"browser": "./dist/module/index.js",
 			"import": "./dist/esm/index.mjs",
 			"require": "./dist/cjs/index.js"
 		},


### PR DESCRIPTION
Esbuild doesn't support downtranspiling `let` in es5 mode. Previously it resolved our module by using the "module" field in `package.json` but they use the package export map now