### PR TITLE
Fix: add types to exports field to compat nodenext module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
 		".": {
 			"browser": "./dist/module/index.js",
 			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.js"
+			"require": "./dist/cjs/index.js",
+			"types": "./dist/types/index.d.ts"
 		},
 		"./package.json": "./package.json",
 		"./": "./*"


### PR DESCRIPTION
See https://github.com/microsoft/TypeScript/issues/46770#issuecomment-966612103 for detail