### PR TITLE
refactor(types): put recurring type in a type variable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,27 +59,29 @@ export let options = {
 	supportLevel,
 };
 
+type Kolorist = (str: string | number) => string;
+
 function kolorist(
 	start: number | string,
 	end: number | string,
 	level: SupportLevel = SupportLevel.ansi
-) {
+): Kolorist {
 	const open = `\x1b[${start}m`;
 	const close = `\x1b[${end}m`;
 	const regex = new RegExp(`\\x1b\\[${end}m`, 'g');
 
-	return (str: string | number) => {
+	return (str) => {
 		return options.enabled && options.supportLevel >= level
 			? open + ('' + str).replace(regex, open) + close
 			: '' + str;
 	};
 }
 
-export function stripColors(str: string | number) {
-	return ('' + str)
-		.replace(/\x1b\[[0-9;]+m/g, '')
-		.replace(/\x1b\]8;;.*?\x07(.*?)\x1b\]8;;\x07/g, (_, group) => group);
-}
+export const stripColors: Kolorist = (str) => (
+	('' + str)
+	.replace(/\x1b\[[0-9;]+m/g, '')
+	.replace(/\x1b\]8;;.*?\x07(.*?)\x1b\]8;;\x07/g, (_, group) => group)
+);
 
 // modifiers
 export const reset = kolorist(0, 0);


### PR DESCRIPTION
## Problem
Previously, the type:
```ts
(str: string | number) => string;
```

was being re-declared for every function:
https://unpkg.com/browse/kolorist@1.7.0/dist/types/index.d.ts

## Changes
Created a type variable so it can be reused. Should be much readable and smaller:

```ts
export declare const enum SupportLevel {
    none = 0,
    ansi = 1,
    ansi256 = 2
}
export declare let options: {
    enabled: boolean;
    supportLevel: SupportLevel;
};
declare type Kolorist = (str: string | number) => string;
export declare const stripColors: Kolorist;
export declare const reset: Kolorist;
export declare const bold: Kolorist;
export declare const dim: Kolorist;
export declare const italic: Kolorist;
export declare const underline: Kolorist;
export declare const inverse: Kolorist;
export declare const hidden: Kolorist;
export declare const strikethrough: Kolorist;
export declare const black: Kolorist;
export declare const red: Kolorist;
export declare const green: Kolorist;
export declare const yellow: Kolorist;
export declare const blue: Kolorist;
export declare const magenta: Kolorist;
export declare const cyan: Kolorist;
export declare const white: Kolorist;
export declare const gray: Kolorist;
export declare const lightGray: Kolorist;
export declare const lightRed: Kolorist;
export declare const lightGreen: Kolorist;
export declare const lightYellow: Kolorist;
export declare const lightBlue: Kolorist;
export declare const lightMagenta: Kolorist;
export declare const lightCyan: Kolorist;
export declare const bgBlack: Kolorist;
export declare const bgRed: Kolorist;
export declare const bgGreen: Kolorist;
export declare const bgYellow: Kolorist;
export declare const bgBlue: Kolorist;
export declare const bgMagenta: Kolorist;
export declare const bgCyan: Kolorist;
export declare const bgWhite: Kolorist;
export declare const bgGray: Kolorist;
export declare const bgLightRed: Kolorist;
export declare const bgLightGreen: Kolorist;
export declare const bgLightYellow: Kolorist;
export declare const bgLightBlue: Kolorist;
export declare const bgLightMagenta: Kolorist;
export declare const bgLightCyan: Kolorist;
export declare const bgLightGray: Kolorist;
export declare const ansi256: (n: number) => Kolorist;
export declare const ansi256Bg: (n: number) => Kolorist;
export declare function link(text: string, url: string): string;
export {};
```
