### PR TITLE
build: use pkgroll

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"@types/node": "^14.14.35",
 				"mocha": "^8.3.2",
 				"node-pty": "^0.10.0",
+				"pkgroll": "^1.8.2",
 				"prettier": "^2.2.1",
 				"rimraf": "^3.0.2",
 				"typescript": "^4.2.3"
@@ -901,6 +902,292 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/@rollup/plugin-alias": {
+			"version": "3.1.9",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-3.1.9.tgz",
+			"integrity": "sha512-QI5fsEvm9bDzt32k39wpOwZhVzRcL5ydcffUHMyLVaVaLeC70I8TJZ17F1z1eMoLu4E/UOcH9BWVkKpIKdrfiw==",
+			"dev": true,
+			"dependencies": {
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0"
+			}
+		},
+		"node_modules/@rollup/plugin-commonjs": {
+			"version": "22.0.2",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-22.0.2.tgz",
+			"integrity": "sha512-//NdP6iIwPbMTcazYsiBMbJW7gfmpHom33u1beiIoHDEM0Q9clvtQB1T0efvMqHeKsGohiHo97BCPCkBXdscwg==",
+			"dev": true,
+			"dependencies": {
+				"@rollup/pluginutils": "^3.1.0",
+				"commondir": "^1.0.1",
+				"estree-walker": "^2.0.1",
+				"glob": "^7.1.6",
+				"is-reference": "^1.2.1",
+				"magic-string": "^0.25.7",
+				"resolve": "^1.17.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^2.68.0"
+			}
+		},
+		"node_modules/@rollup/plugin-commonjs/node_modules/@rollup/pluginutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+			"dev": true,
+			"dependencies": {
+				"@types/estree": "0.0.39",
+				"estree-walker": "^1.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0"
+			}
+		},
+		"node_modules/@rollup/plugin-commonjs/node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+			"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+			"dev": true
+		},
+		"node_modules/@rollup/plugin-commonjs/node_modules/@types/estree": {
+			"version": "0.0.39",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+			"dev": true
+		},
+		"node_modules/@rollup/plugin-commonjs/node_modules/magic-string": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+			"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+			"dev": true,
+			"dependencies": {
+				"sourcemap-codec": "^1.4.8"
+			}
+		},
+		"node_modules/@rollup/plugin-inject": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-4.0.4.tgz",
+			"integrity": "sha512-4pbcU4J/nS+zuHk+c+OL3WtmEQhqxlZ9uqfjQMQDOHOPld7PsCd8k5LWs8h5wjwJN7MgnAn768F2sDxEP4eNFQ==",
+			"dev": true,
+			"dependencies": {
+				"@rollup/pluginutils": "^3.1.0",
+				"estree-walker": "^2.0.1",
+				"magic-string": "^0.25.7"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0 || ^2.0.0"
+			}
+		},
+		"node_modules/@rollup/plugin-inject/node_modules/@rollup/pluginutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+			"dev": true,
+			"dependencies": {
+				"@types/estree": "0.0.39",
+				"estree-walker": "^1.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0"
+			}
+		},
+		"node_modules/@rollup/plugin-inject/node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+			"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+			"dev": true
+		},
+		"node_modules/@rollup/plugin-inject/node_modules/@types/estree": {
+			"version": "0.0.39",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+			"dev": true
+		},
+		"node_modules/@rollup/plugin-inject/node_modules/magic-string": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+			"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+			"dev": true,
+			"dependencies": {
+				"sourcemap-codec": "^1.4.8"
+			}
+		},
+		"node_modules/@rollup/plugin-json": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+			"integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+			"dev": true,
+			"dependencies": {
+				"@rollup/pluginutils": "^3.0.8"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0 || ^2.0.0"
+			}
+		},
+		"node_modules/@rollup/plugin-json/node_modules/@rollup/pluginutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+			"dev": true,
+			"dependencies": {
+				"@types/estree": "0.0.39",
+				"estree-walker": "^1.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0"
+			}
+		},
+		"node_modules/@rollup/plugin-json/node_modules/@types/estree": {
+			"version": "0.0.39",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+			"dev": true
+		},
+		"node_modules/@rollup/plugin-json/node_modules/estree-walker": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+			"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+			"dev": true
+		},
+		"node_modules/@rollup/plugin-node-resolve": {
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.3.0.tgz",
+			"integrity": "sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==",
+			"dev": true,
+			"dependencies": {
+				"@rollup/pluginutils": "^3.1.0",
+				"@types/resolve": "1.17.1",
+				"deepmerge": "^4.2.2",
+				"is-builtin-module": "^3.1.0",
+				"is-module": "^1.0.0",
+				"resolve": "^1.19.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^2.42.0"
+			}
+		},
+		"node_modules/@rollup/plugin-node-resolve/node_modules/@rollup/pluginutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+			"dev": true,
+			"dependencies": {
+				"@types/estree": "0.0.39",
+				"estree-walker": "^1.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0"
+			}
+		},
+		"node_modules/@rollup/plugin-node-resolve/node_modules/@types/estree": {
+			"version": "0.0.39",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+			"dev": true
+		},
+		"node_modules/@rollup/plugin-node-resolve/node_modules/estree-walker": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+			"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+			"dev": true
+		},
+		"node_modules/@rollup/plugin-replace": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-4.0.0.tgz",
+			"integrity": "sha512-+rumQFiaNac9y64OHtkHGmdjm7us9bo1PlbgQfdihQtuNxzjpaB064HbRnewUOggLQxVCCyINfStkgmBeQpv1g==",
+			"dev": true,
+			"dependencies": {
+				"@rollup/pluginutils": "^3.1.0",
+				"magic-string": "^0.25.7"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0 || ^2.0.0"
+			}
+		},
+		"node_modules/@rollup/plugin-replace/node_modules/@rollup/pluginutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+			"dev": true,
+			"dependencies": {
+				"@types/estree": "0.0.39",
+				"estree-walker": "^1.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0"
+			}
+		},
+		"node_modules/@rollup/plugin-replace/node_modules/@types/estree": {
+			"version": "0.0.39",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+			"dev": true
+		},
+		"node_modules/@rollup/plugin-replace/node_modules/estree-walker": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+			"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+			"dev": true
+		},
+		"node_modules/@rollup/plugin-replace/node_modules/magic-string": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+			"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+			"dev": true,
+			"dependencies": {
+				"sourcemap-codec": "^1.4.8"
+			}
+		},
+		"node_modules/@rollup/pluginutils": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+			"integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+			"dev": true,
+			"dependencies": {
+				"estree-walker": "^2.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			}
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+			"integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+			"dev": true
+		},
 		"node_modules/@types/is-ci": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/is-ci/-/is-ci-3.0.0.tgz",
@@ -933,6 +1220,15 @@
 			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
 			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
 			"dev": true
+		},
+		"node_modules/@types/resolve": {
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+			"integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@types/semver": {
 			"version": "6.2.3",
@@ -1115,6 +1411,18 @@
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
 			"dev": true
+		},
+		"node_modules/builtin-modules": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+			"integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/call-bind": {
 			"version": "1.0.2",
@@ -1319,6 +1627,12 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
 		},
+		"node_modules/commondir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+			"integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+			"dev": true
+		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1445,6 +1759,15 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
 			"integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/deepmerge": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
+			"integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -2013,6 +2336,12 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+			"dev": true
+		},
 		"node_modules/extendable-error": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
@@ -2230,20 +2559,23 @@
 			}
 		},
 		"node_modules/glob": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
 			"dev": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
 				"inherits": "2",
-				"minimatch": "^3.0.4",
+				"minimatch": "^3.1.1",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
 			},
 			"engines": {
 				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/glob-parent": {
@@ -2256,6 +2588,18 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/glob/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/globalthis": {
@@ -2557,6 +2901,21 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-builtin-module": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+			"integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+			"dev": true,
+			"dependencies": {
+				"builtin-modules": "^3.3.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-callable": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -2638,6 +2997,12 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+			"integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+			"dev": true
+		},
 		"node_modules/is-negative-zero": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
@@ -2681,6 +3046,15 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/is-reference": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+			"integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/estree": "*"
 			}
 		},
 		"node_modules/is-regex": {
@@ -2934,6 +3308,18 @@
 			"dependencies": {
 				"pseudomap": "^1.0.2",
 				"yallist": "^2.1.2"
+			}
+		},
+		"node_modules/magic-string": {
+			"version": "0.26.7",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
+			"integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
+			"dev": true,
+			"dependencies": {
+				"sourcemap-codec": "^1.4.8"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/map-obj": {
@@ -3454,6 +3840,38 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/pkgroll": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/pkgroll/-/pkgroll-1.8.2.tgz",
+			"integrity": "sha512-7lLaylmnGMr7xUl4DWEyWab2+SiBXZCVfmeDNL5+njaTeKgt5PMngqN9x9BZwZW7mGGG7aKrgqSWhXt0qCwRNA==",
+			"dev": true,
+			"dependencies": {
+				"@rollup/plugin-alias": "^3.1.9",
+				"@rollup/plugin-commonjs": "^22.0.2",
+				"@rollup/plugin-inject": "^4.0.4",
+				"@rollup/plugin-json": "^4.1.0",
+				"@rollup/plugin-node-resolve": "^13.3.0",
+				"@rollup/plugin-replace": "^4.0.0",
+				"@rollup/pluginutils": "^4.2.1",
+				"esbuild": "^0.15.15",
+				"magic-string": "^0.26.7",
+				"rollup": "^2.79.1"
+			},
+			"bin": {
+				"pkgroll": "dist/cli.js"
+			},
+			"funding": {
+				"url": "https://github.com/privatenumber/pkgroll?sponsor=1"
+			},
+			"peerDependencies": {
+				"typescript": "^4.1"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/preferred-pm": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/preferred-pm/-/preferred-pm-3.0.3.tgz",
@@ -3779,6 +4197,21 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rollup": {
+			"version": "2.79.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+			"integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+			"dev": true,
+			"bin": {
+				"rollup": "dist/bin/rollup"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.2"
 			}
 		},
 		"node_modules/run-parallel": {
@@ -4136,6 +4569,13 @@
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
 			}
+		},
+		"node_modules/sourcemap-codec": {
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+			"deprecated": "Please use @jridgewell/sourcemap-codec instead",
+			"dev": true
 		},
 		"node_modules/spawndamnit": {
 			"version": "2.0.0",
@@ -5554,6 +5994,246 @@
 				"fastq": "^1.6.0"
 			}
 		},
+		"@rollup/plugin-alias": {
+			"version": "3.1.9",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-3.1.9.tgz",
+			"integrity": "sha512-QI5fsEvm9bDzt32k39wpOwZhVzRcL5ydcffUHMyLVaVaLeC70I8TJZ17F1z1eMoLu4E/UOcH9BWVkKpIKdrfiw==",
+			"dev": true,
+			"requires": {
+				"slash": "^3.0.0"
+			}
+		},
+		"@rollup/plugin-commonjs": {
+			"version": "22.0.2",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-22.0.2.tgz",
+			"integrity": "sha512-//NdP6iIwPbMTcazYsiBMbJW7gfmpHom33u1beiIoHDEM0Q9clvtQB1T0efvMqHeKsGohiHo97BCPCkBXdscwg==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^3.1.0",
+				"commondir": "^1.0.1",
+				"estree-walker": "^2.0.1",
+				"glob": "^7.1.6",
+				"is-reference": "^1.2.1",
+				"magic-string": "^0.25.7",
+				"resolve": "^1.17.0"
+			},
+			"dependencies": {
+				"@rollup/pluginutils": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+					"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+					"dev": true,
+					"requires": {
+						"@types/estree": "0.0.39",
+						"estree-walker": "^1.0.1",
+						"picomatch": "^2.2.2"
+					},
+					"dependencies": {
+						"estree-walker": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+							"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+							"dev": true
+						}
+					}
+				},
+				"@types/estree": {
+					"version": "0.0.39",
+					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+					"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+					"dev": true
+				},
+				"magic-string": {
+					"version": "0.25.9",
+					"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+					"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+					"dev": true,
+					"requires": {
+						"sourcemap-codec": "^1.4.8"
+					}
+				}
+			}
+		},
+		"@rollup/plugin-inject": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-4.0.4.tgz",
+			"integrity": "sha512-4pbcU4J/nS+zuHk+c+OL3WtmEQhqxlZ9uqfjQMQDOHOPld7PsCd8k5LWs8h5wjwJN7MgnAn768F2sDxEP4eNFQ==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^3.1.0",
+				"estree-walker": "^2.0.1",
+				"magic-string": "^0.25.7"
+			},
+			"dependencies": {
+				"@rollup/pluginutils": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+					"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+					"dev": true,
+					"requires": {
+						"@types/estree": "0.0.39",
+						"estree-walker": "^1.0.1",
+						"picomatch": "^2.2.2"
+					},
+					"dependencies": {
+						"estree-walker": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+							"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+							"dev": true
+						}
+					}
+				},
+				"@types/estree": {
+					"version": "0.0.39",
+					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+					"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+					"dev": true
+				},
+				"magic-string": {
+					"version": "0.25.9",
+					"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+					"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+					"dev": true,
+					"requires": {
+						"sourcemap-codec": "^1.4.8"
+					}
+				}
+			}
+		},
+		"@rollup/plugin-json": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+			"integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^3.0.8"
+			},
+			"dependencies": {
+				"@rollup/pluginutils": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+					"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+					"dev": true,
+					"requires": {
+						"@types/estree": "0.0.39",
+						"estree-walker": "^1.0.1",
+						"picomatch": "^2.2.2"
+					}
+				},
+				"@types/estree": {
+					"version": "0.0.39",
+					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+					"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+					"dev": true
+				},
+				"estree-walker": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+					"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+					"dev": true
+				}
+			}
+		},
+		"@rollup/plugin-node-resolve": {
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.3.0.tgz",
+			"integrity": "sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^3.1.0",
+				"@types/resolve": "1.17.1",
+				"deepmerge": "^4.2.2",
+				"is-builtin-module": "^3.1.0",
+				"is-module": "^1.0.0",
+				"resolve": "^1.19.0"
+			},
+			"dependencies": {
+				"@rollup/pluginutils": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+					"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+					"dev": true,
+					"requires": {
+						"@types/estree": "0.0.39",
+						"estree-walker": "^1.0.1",
+						"picomatch": "^2.2.2"
+					}
+				},
+				"@types/estree": {
+					"version": "0.0.39",
+					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+					"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+					"dev": true
+				},
+				"estree-walker": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+					"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+					"dev": true
+				}
+			}
+		},
+		"@rollup/plugin-replace": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-4.0.0.tgz",
+			"integrity": "sha512-+rumQFiaNac9y64OHtkHGmdjm7us9bo1PlbgQfdihQtuNxzjpaB064HbRnewUOggLQxVCCyINfStkgmBeQpv1g==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^3.1.0",
+				"magic-string": "^0.25.7"
+			},
+			"dependencies": {
+				"@rollup/pluginutils": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+					"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+					"dev": true,
+					"requires": {
+						"@types/estree": "0.0.39",
+						"estree-walker": "^1.0.1",
+						"picomatch": "^2.2.2"
+					}
+				},
+				"@types/estree": {
+					"version": "0.0.39",
+					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+					"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+					"dev": true
+				},
+				"estree-walker": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+					"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+					"dev": true
+				},
+				"magic-string": {
+					"version": "0.25.9",
+					"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+					"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+					"dev": true,
+					"requires": {
+						"sourcemap-codec": "^1.4.8"
+					}
+				}
+			}
+		},
+		"@rollup/pluginutils": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+			"integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+			"dev": true,
+			"requires": {
+				"estree-walker": "^2.0.1",
+				"picomatch": "^2.2.2"
+			}
+		},
+		"@types/estree": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+			"integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+			"dev": true
+		},
 		"@types/is-ci": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/is-ci/-/is-ci-3.0.0.tgz",
@@ -5586,6 +6266,15 @@
 			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
 			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
 			"dev": true
+		},
+		"@types/resolve": {
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+			"integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/semver": {
 			"version": "6.2.3",
@@ -5725,6 +6414,12 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"dev": true
+		},
+		"builtin-modules": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+			"integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
 			"dev": true
 		},
 		"call-bind": {
@@ -5877,6 +6572,12 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
 		},
+		"commondir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+			"integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+			"dev": true
+		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5981,6 +6682,12 @@
 					"dev": true
 				}
 			}
+		},
+		"deepmerge": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
+			"integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==",
+			"dev": true
 		},
 		"defaults": {
 			"version": "1.0.4",
@@ -6306,6 +7013,12 @@
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
 			"dev": true
 		},
+		"estree-walker": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+			"dev": true
+		},
 		"extendable-error": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
@@ -6471,17 +7184,28 @@
 			"dev": true
 		},
 		"glob": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
 				"inherits": "2",
-				"minimatch": "^3.0.4",
+				"minimatch": "^3.1.1",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
+			},
+			"dependencies": {
+				"minimatch": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+					"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				}
 			}
 		},
 		"glob-parent": {
@@ -6711,6 +7435,15 @@
 				"has-tostringtag": "^1.0.0"
 			}
 		},
+		"is-builtin-module": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+			"integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+			"dev": true,
+			"requires": {
+				"builtin-modules": "^3.3.0"
+			}
+		},
 		"is-callable": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -6765,6 +7498,12 @@
 				"is-extglob": "^2.1.1"
 			}
 		},
+		"is-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+			"integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+			"dev": true
+		},
 		"is-negative-zero": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
@@ -6791,6 +7530,15 @@
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
 			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
 			"dev": true
+		},
+		"is-reference": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+			"integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+			"dev": true,
+			"requires": {
+				"@types/estree": "*"
+			}
 		},
 		"is-regex": {
 			"version": "1.1.4",
@@ -6985,6 +7733,15 @@
 			"requires": {
 				"pseudomap": "^1.0.2",
 				"yallist": "^2.1.2"
+			}
+		},
+		"magic-string": {
+			"version": "0.26.7",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
+			"integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
+			"dev": true,
+			"requires": {
+				"sourcemap-codec": "^1.4.8"
 			}
 		},
 		"map-obj": {
@@ -7366,6 +8123,24 @@
 				}
 			}
 		},
+		"pkgroll": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/pkgroll/-/pkgroll-1.8.2.tgz",
+			"integrity": "sha512-7lLaylmnGMr7xUl4DWEyWab2+SiBXZCVfmeDNL5+njaTeKgt5PMngqN9x9BZwZW7mGGG7aKrgqSWhXt0qCwRNA==",
+			"dev": true,
+			"requires": {
+				"@rollup/plugin-alias": "^3.1.9",
+				"@rollup/plugin-commonjs": "^22.0.2",
+				"@rollup/plugin-inject": "^4.0.4",
+				"@rollup/plugin-json": "^4.1.0",
+				"@rollup/plugin-node-resolve": "^13.3.0",
+				"@rollup/plugin-replace": "^4.0.0",
+				"@rollup/pluginutils": "^4.2.1",
+				"esbuild": "^0.15.15",
+				"magic-string": "^0.26.7",
+				"rollup": "^2.79.1"
+			}
+		},
 		"preferred-pm": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/preferred-pm/-/preferred-pm-3.0.3.tgz",
@@ -7598,6 +8373,15 @@
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
+			}
+		},
+		"rollup": {
+			"version": "2.79.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+			"integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+			"dev": true,
+			"requires": {
+				"fsevents": "~2.3.2"
 			}
 		},
 		"run-parallel": {
@@ -7860,6 +8644,12 @@
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
 			}
+		},
+		"sourcemap-codec": {
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+			"dev": true
 		},
 		"spawndamnit": {
 			"version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
 	"name": "kolorist",
 	"version": "1.7.0",
 	"description": "A tiny utility to colorize stdin/stdout",
-	"main": "dist/cjs/index.js",
-	"module": "dist/module/index.js",
-	"types": "dist/types/index.d.ts",
+	"main": "dist/index.cjs",
+	"module": "dist/index.mjs",
+	"types": "dist/index.d.ts",
 	"scripts": {
 		"test": "mocha -r @esbuild-kit/cjs-loader --extension ts,js src/*.test.ts",
-		"build": "rimraf dist/ && tsc && tsc -p tsconfig.module.json && tsc -p tsconfig.esm.json && node tools/post-build.js",
+		"build": "rimraf dist && pkgroll",
 		"prepublishOnly": "npm run build"
 	},
 	"author": "Marvin Hagemeister <hello@marvinh.dev>",
@@ -23,16 +23,17 @@
 		"@types/node": "^14.14.35",
 		"mocha": "^8.3.2",
 		"node-pty": "^0.10.0",
+		"pkgroll": "^1.8.2",
 		"prettier": "^2.2.1",
 		"rimraf": "^3.0.2",
 		"typescript": "^4.2.3"
 	},
 	"exports": {
 		".": {
-			"types": "./dist/types/index.d.ts",
-			"browser": "./dist/module/index.js",
-			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.js"
+			"types": "./dist/index.d.ts",
+			"browser": "./dist/index.mjs",
+			"import": "./dist/index.mjs",
+			"require": "./dist/index.cjs"
 		},
 		"./package.json": "./package.json",
 		"./*": "./*"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 	"types": "dist/index.d.ts",
 	"scripts": {
 		"test": "mocha -r @esbuild-kit/cjs-loader --extension ts,js src/*.test.ts",
+		"type-check": "tsc --noEmit",
 		"build": "rimraf dist && pkgroll",
 		"prepublishOnly": "npm run build"
 	},

--- a/tools/post-build.js
+++ b/tools/post-build.js
@@ -1,5 +1,0 @@
-const path = require('path');
-const fs = require('fs');
-
-const dir = path.join(__dirname, '..', 'dist', 'esm');
-fs.copyFileSync(path.join(dir, 'index.js'), path.join(dir, 'index.mjs'));

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,9 +1,0 @@
-{
-	"extends": "./tsconfig.json",
-	"compilerOptions": {
-		"module": "ESNext",
-		"declaration": true,
-		"declarationDir": "./dist/types/",
-		"outDir": "./dist/esm/"
-	}
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,7 @@
 	"compilerOptions": {
 		"strict": true,
 		"target": "ES2019",
-		"module": "CommonJS",
-		"moduleResolution": "node",
-		"outDir": "dist/cjs/",
-		"sourceMap": true,
-		"allowJs": true
+		"skipLibCheck": true,
 	},
 	"files": ["./src/index.ts"]
 }

--- a/tsconfig.module.json
+++ b/tsconfig.module.json
@@ -1,8 +1,0 @@
-{
-	"extends": "./tsconfig.json",
-	"compilerOptions": {
-		"module": "ESNext",
-		"target": "ES5",
-		"outDir": "./dist/module/"
-	}
-}


### PR DESCRIPTION
## Problem
- Using TypeScript to build is slow and requires a complicated setup
- Benchmark:
```
$ hyperfine 'npm run build'
Benchmark 1: npm run build
  Time (mean ± σ):      7.043 s ±  0.184 s    [User: 13.169 s, System: 0.690 s]
  Range (min … max):    6.815 s …  7.372 s    10 runs
```

## Changes
- Use [pkgroll](https://github.com/privatenumber/pkgroll) for a simpler & faster build step
- Restructure `dist` directory to be simpler
	- This could be a breaking change for users that are directly importing a specific path
- Remove `tools/post-build.js` as pkgroll automatically outputs `.mjs` file
- I decided not to output sourcemaps because the distribution file is not very different from the source file. Also, because Node.js is the primary use-case, which can't load source-maps out of the box. I can add it back if you'd like.
- Removed unused tsconfig files
- Refactored `tsconfig.json` to remove irrelevant properties and speed it up

- Benchmark:
```
$ hyperfine 'npm run build'
Benchmark 1: npm run build
  Time (mean ± σ):      1.928 s ±  0.073 s    [User: 2.906 s, System: 0.295 s]
  Range (min … max):    1.873 s …  2.075 s    10 runs
```